### PR TITLE
Updated mercury's dependencies related to ZCash 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/howeyc/fsnotify v0.9.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/influxdata/influxdb v1.7.7 // indirect
-	github.com/iqoption/zecutil v0.0.0-20181123060914-2cb80ea5c0ce // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
 	github.com/karalabe/usb v0.0.0-20190819132248-550797b1cad8 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,8 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20190712234253-ed1100a1c015 // indirect
 	github.com/btcsuite/btcd v0.0.0-20190807005414-4063feeff79a
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
-	github.com/btcsuite/golangcrypto v0.0.0-20150304025918-53f62d9b43e8
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/codahale/blake2 v0.0.0-20150924215134-8d10d0420cbf
-	github.com/cpacia/bchutil v0.0.0-20181003130114-b126f6a35b6c // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
@@ -26,7 +24,7 @@ require (
 	github.com/howeyc/fsnotify v0.9.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/influxdata/influxdb v1.7.7 // indirect
-	github.com/iqoption/zecutil v0.0.0-20181123060914-2cb80ea5c0ce
+	github.com/iqoption/zecutil v0.0.0-20181123060914-2cb80ea5c0ce // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
 	github.com/karalabe/usb v0.0.0-20190819132248-550797b1cad8 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufo
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
-github.com/btcsuite/golangcrypto v0.0.0-20150304025918-53f62d9b43e8 h1:nOsAWScwueMVk/VLm/dvQQD7DuanyvAUb6B3P3eT274=
-github.com/btcsuite/golangcrypto v0.0.0-20150304025918-53f62d9b43e8/go.mod h1:tYvUd8KLhm/oXvUeSEs2VlLghFjQt9+ZaF9ghH0JNjc=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
@@ -35,8 +33,6 @@ github.com/codahale/blake2 v0.0.0-20150924215134-8d10d0420cbf/go.mod h1:BO2rLUAZ
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/cpacia/bchutil v0.0.0-20181003130114-b126f6a35b6c h1:4e6Zsb6LFd3kadoMiut2zcd3hCb4zywpJnQa8+NV2Cs=
-github.com/cpacia/bchutil v0.0.0-20181003130114-b126f6a35b6c/go.mod h1:k5D13LCXSsMrQyfdW0yGYs4GWUvirqoxHht8qwtqyRY=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -116,9 +112,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/ltcsuite/ltcd v0.0.0-20190519120615-e27ee083f08f/go.mod h1:PPSOmqRCtob0mC9fTmLMlV2wfjPqEUNZFA/CiWxFC8w=
-github.com/ltcsuite/ltcutil v0.0.0-20190507082654-23cdfa9fcc3d/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=
-github.com/ltcsuite/ltcutil v0.0.0-20190507133322-23cdfa9fcc3d/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7 h1:UvNzAPfBrKMENVbQ4mr4ccA9sW+W1Ihl0Yh1s0BiVAg=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
-github.com/iqoption/zecutil v0.0.0-20181123060914-2cb80ea5c0ce h1:KCJDYfLQHYrBAFRngEEsZDYuhxZNoqGhQaLKfVzpam0=
-github.com/iqoption/zecutil v0.0.0-20181123060914-2cb80ea5c0ce/go.mod h1:VF8vX2N4L4sQfiO0uCzjWxrogRjW42n8ssNB/1ozFCA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/sdk/client/btcclient/btc.go
+++ b/sdk/client/btcclient/btc.go
@@ -50,12 +50,12 @@ type BchClient struct {
 }
 
 func MercuryURL(network btctypes.Network) string {
-	switch network {
-	case btctypes.BtcMainnet, btctypes.ZecMainnet, btctypes.BchMainnet:
+	switch network.String() {
+	case btctypes.BtcMainnet.String(), btctypes.ZecMainnet.String(), btctypes.BchMainnet.String():
 		return fmt.Sprintf("%s/%s/mainnet", mclient.MercuryURL, network.Chain().String())
-	case btctypes.BtcTestnet, btctypes.ZecTestnet, btctypes.BchTestnet:
+	case btctypes.BtcTestnet.String(), btctypes.ZecTestnet.String(), btctypes.BchTestnet.String():
 		return fmt.Sprintf("%s/%s/testnet", mclient.MercuryURL, network.Chain().String())
-	case btctypes.BtcLocalnet, btctypes.ZecLocalnet, btctypes.BchLocalnet:
+	case btctypes.BtcLocalnet.String(), btctypes.ZecLocalnet.String(), btctypes.BchLocalnet.String():
 		return fmt.Sprintf("http://0.0.0.0:5000/%s/testnet", network.Chain().String())
 	default:
 		panic(types.ErrUnknownNetwork)

--- a/types/btctypes/btccompatAddress.go
+++ b/types/btctypes/btccompatAddress.go
@@ -1,0 +1,166 @@
+package btctypes
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/renproject/mercury/types"
+	"github.com/renproject/mercury/types/btctypes/bch"
+	"golang.org/x/crypto/ripemd160"
+)
+
+type BtcCompatP2PKHAddress struct {
+	pubKeyHash []byte
+	network    Network
+}
+
+func NewAddressPubKey(pubKey []byte, network Network) btcutil.Address {
+	return &BtcCompatP2PKHAddress{btcutil.Hash160(pubKey), network}
+}
+
+func NewAddressPubKeyHash(pubKeyHash []byte, network Network) btcutil.Address {
+	return &BtcCompatP2PKHAddress{pubKeyHash, network}
+}
+
+func (address *BtcCompatP2PKHAddress) EncodeAddress() string {
+	return EncodeAddress(P2PKH, address.pubKeyHash, address.network)
+}
+
+func (address *BtcCompatP2PKHAddress) String() string {
+	return address.EncodeAddress()
+}
+
+func (address *BtcCompatP2PKHAddress) ScriptAddress() []byte {
+	return address.pubKeyHash
+}
+
+func (address *BtcCompatP2PKHAddress) IsForNet(params *chaincfg.Params) bool {
+	return address.network.Params().Name == params.Name
+}
+
+type BtcCompatP2SHAddress struct {
+	scriptHash []byte
+	network    Network
+}
+
+func NewAddressScriptHash(serializedScript []byte, network Network) btcutil.Address {
+	return &BtcCompatP2SHAddress{btcutil.Hash160(serializedScript), network}
+}
+
+func NewAddressScriptHashFromHash(scriptHash []byte, network Network) btcutil.Address {
+	return &BtcCompatP2PKHAddress{scriptHash, network}
+}
+
+func (address *BtcCompatP2SHAddress) EncodeAddress() string {
+	return EncodeAddress(P2SH, address.scriptHash, address.network)
+}
+
+func (address *BtcCompatP2SHAddress) String() string {
+	return address.EncodeAddress()
+}
+
+func (address *BtcCompatP2SHAddress) ScriptAddress() []byte {
+	return address.scriptHash
+}
+
+func (address *BtcCompatP2SHAddress) IsForNet(params *chaincfg.Params) bool {
+	return address.network.Params().Name == params.Name
+}
+
+func EncodeAddress(addrType AddressType, hash []byte, network Network) string {
+	switch network := network.(type) {
+	case ZecNetwork:
+		return encodeAddress(hash, network.Prefix(addrType))
+	default:
+		panic(types.ErrUnknownNetwork)
+	}
+}
+
+func DecodeAddress(address string) (btcutil.Address, error) {
+	var decoded = base58.Decode(address)
+	if len(decoded) != 26 || len(decoded) != 25 {
+		return nil, base58.ErrInvalidFormat
+	}
+
+	var cksum [4]byte
+	copy(cksum[:], decoded[len(decoded)-4:])
+	if checksum(decoded[:len(decoded)-4]) != cksum {
+		return nil, base58.ErrChecksum
+	}
+
+	if len(decoded)-6 != ripemd160.Size || len(decoded)-5 != ripemd160.Size {
+		return nil, errors.New("incorrect payload len")
+	}
+
+	var net Network
+	var addrType AddressType
+	var hash []byte
+	if len(decoded) == 26 {
+		addrType, net = ParsePrefix(decoded[:2])
+		copy(hash, decoded[2:22])
+	} else {
+		addrType, net = ParsePrefix(decoded[:1])
+		copy(hash, decoded[1:21])
+	}
+
+	switch addrType {
+	case P2PKH:
+		return &BtcCompatP2PKHAddress{
+			pubKeyHash: hash,
+			network:    net,
+		}, nil
+	case P2SH:
+		return &BtcCompatP2SHAddress{
+			scriptHash: hash,
+			network:    net,
+		}, nil
+	}
+
+	return nil, errors.New("unknown address")
+}
+
+// PayToAddrScript gets the PayToAddrScript for an address on the given blockchain
+func PayToAddrScript(address Address, network Network) ([]byte, error) {
+	switch network.Chain() {
+	case types.Bitcoin:
+		return txscript.PayToAddrScript(address)
+	case types.BitcoinCash:
+		return bch.PayToAddrScript(address)
+	}
+
+	switch address := address.(type) {
+	case *BtcCompatP2PKHAddress:
+		return txscript.NewScriptBuilder().AddOp(txscript.OP_DUP).AddOp(txscript.OP_HASH160).
+			AddData(address.pubKeyHash).AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG).
+			Script()
+	case *BtcCompatP2SHAddress:
+		return txscript.NewScriptBuilder().AddOp(txscript.OP_HASH160).AddData(address.scriptHash).
+			AddOp(txscript.OP_EQUAL).Script()
+	default:
+		return nil, fmt.Errorf("unsupported address type %T", address)
+	}
+}
+
+func encodeAddress(addrHash, prefix []byte) string {
+	var (
+		body  = append(prefix, addrHash...)
+		chk   = checksum(body)
+		cksum [4]byte
+	)
+	copy(cksum[:], chk[:4])
+	return base58.Encode(append(body, cksum[:]...))
+}
+
+func checksum(input []byte) (cksum [4]byte) {
+	var (
+		h  = sha256.Sum256(input)
+		h2 = sha256.Sum256(h[:])
+	)
+	copy(cksum[:], h2[:4])
+	return
+}

--- a/types/btctypes/btctypes.go
+++ b/types/btctypes/btctypes.go
@@ -10,6 +10,7 @@ import (
 type Network interface {
 	types.Network
 
+	Prefix(addrType AddressType) []byte
 	Params() *chaincfg.Params
 	SegWitEnabled() bool
 }
@@ -20,10 +21,6 @@ const (
 	BtcLocalnet network = 0
 	BtcMainnet  network = 1
 	BtcTestnet  network = 2
-
-	ZecLocalnet network = 3
-	ZecMainnet  network = 4
-	ZecTestnet  network = 5
 
 	BchLocalnet network = 6
 	BchMainnet  network = 7
@@ -59,21 +56,6 @@ func NewBtcNetwork(network string) Network {
 	}
 }
 
-// NewZecNetwork parse the zec network from a string.
-func NewZecNetwork(network string) Network {
-	network = strings.ToLower(strings.TrimSpace(network))
-	switch network {
-	case "mainnet":
-		return ZecMainnet
-	case "testnet", "testnet3":
-		return ZecTestnet
-	case "localnet", "localhost":
-		return ZecLocalnet
-	default:
-		panic(types.ErrUnknownNetwork)
-	}
-}
-
 // NewBchNetwork parse the ltc network from a string.
 func NewBchNetwork(network string) Network {
 	network = strings.ToLower(strings.TrimSpace(network))
@@ -92,9 +74,9 @@ func NewBchNetwork(network string) Network {
 // Params returns the params config for the network
 func (network network) Params() *chaincfg.Params {
 	switch network {
-	case BtcMainnet, ZecMainnet, BchMainnet:
+	case BtcMainnet, BchMainnet:
 		return &chaincfg.MainNetParams
-	case BtcTestnet, BtcLocalnet, ZecTestnet, ZecLocalnet, BchTestnet, BchLocalnet:
+	case BtcTestnet, BtcLocalnet, BchTestnet, BchLocalnet:
 		return &chaincfg.TestNet3Params
 	default:
 		panic(types.ErrUnknownNetwork)
@@ -116,11 +98,11 @@ func (network network) SegWitEnabled() bool {
 // String implements the `Stringer` interface.
 func (network network) String() string {
 	switch network {
-	case BtcMainnet, ZecMainnet, BchMainnet:
+	case BtcMainnet, BchMainnet:
 		return "mainnet"
-	case BtcTestnet, ZecTestnet, BchTestnet:
+	case BtcTestnet, BchTestnet:
 		return "testnet"
-	case BtcLocalnet, ZecLocalnet, BchLocalnet:
+	case BtcLocalnet, BchLocalnet:
 		return "localnet"
 	default:
 		panic(types.ErrUnknownNetwork)
@@ -132,11 +114,14 @@ func (network network) Chain() types.Chain {
 	switch network {
 	case BtcMainnet, BtcTestnet, BtcLocalnet:
 		return types.Bitcoin
-	case ZecMainnet, ZecTestnet, ZecLocalnet:
-		return types.ZCash
 	case BchMainnet, BchTestnet, BchLocalnet:
 		return types.BitcoinCash
 	default:
 		panic(types.ErrUnknownNetwork)
 	}
+}
+
+// Prefix implements the types.Network interface.
+func (network network) Prefix(addrType AddressType) []byte {
+	panic("unimplemented")
 }

--- a/types/btctypes/network.go
+++ b/types/btctypes/network.go
@@ -1,0 +1,96 @@
+package btctypes
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/renproject/mercury/types"
+)
+
+type ZecNetwork struct {
+	p2shPrefix  []byte
+	p2pkhPrefix []byte
+	params      *chaincfg.Params
+	netString   string
+}
+
+var ZecMainnet = ZecNetwork{
+	p2pkhPrefix: []byte{0x1C, 0xB8},
+	p2shPrefix:  []byte{0x1C, 0xBD},
+	netString:   "mainnet",
+	params:      &chaincfg.MainNetParams,
+}
+
+var ZecTestnet = ZecNetwork{
+	p2pkhPrefix: []byte{0x1D, 0x25},
+	p2shPrefix:  []byte{0x1C, 0xBA},
+	netString:   "testnet",
+	params:      &chaincfg.TestNet3Params,
+}
+
+var ZecRegnet = ZecNetwork{
+	p2pkhPrefix: []byte{0x1D, 0x25},
+	p2shPrefix:  []byte{0x1C, 0xBA},
+	netString:   "regtest",
+	params:      &chaincfg.RegressionNetParams,
+}
+
+var ZecLocalnet = ZecTestnet
+
+func NewZecNetwork(network string) ZecNetwork {
+	switch network {
+	case "mainnet":
+		return ZecMainnet
+	case "testnet", "testnet3":
+		return ZecTestnet
+	case "localnet", "localhost":
+		return ZecLocalnet
+	default:
+		panic(types.ErrUnknownNetwork)
+	}
+}
+
+func (net ZecNetwork) Chain() types.Chain {
+	return types.ZCash
+}
+
+func (net ZecNetwork) String() string {
+	return net.netString
+}
+
+func (net ZecNetwork) SegWitEnabled() bool {
+	return false
+}
+
+func (net ZecNetwork) Params() *chaincfg.Params {
+	return net.params
+}
+
+func (net ZecNetwork) Prefix(addrType AddressType) []byte {
+	switch addrType {
+	case P2PKH:
+		return net.p2pkhPrefix
+	case P2SH:
+		return net.p2shPrefix
+	default:
+		panic(ErrUnknownAddressType)
+	}
+}
+
+func ParsePrefix(prefix []byte) (AddressType, Network) {
+	if bytes.Equal(prefix, ZecTestnet.p2pkhPrefix) {
+		return P2PKH, ZecTestnet
+	}
+	if bytes.Equal(prefix, ZecTestnet.p2shPrefix) {
+		return P2SH, ZecTestnet
+	}
+
+	if bytes.Equal(prefix, ZecMainnet.p2shPrefix) {
+		return P2SH, ZecMainnet
+	}
+
+	if bytes.Equal(prefix, ZecMainnet.p2pkhPrefix) {
+		return P2PKH, ZecMainnet
+	}
+	panic("unknown prefix")
+}

--- a/types/btctypes/utxo.go
+++ b/types/btctypes/utxo.go
@@ -5,13 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/codahale/blake2"
-	"github.com/iqoption/zecutil"
 	"github.com/renproject/mercury/types"
 )
 
@@ -114,11 +111,11 @@ func (u *utxo) SigHash(hashType txscript.SigHashType, msgTx MsgTx, idx int) ([]b
 			return txscript.CalcWitnessSigHash(u.script, txscript.NewTxSigHashes(msgTx.MsgTx), hashType, msgTx.MsgTx, idx, int64(u.amount))
 		}
 		return txscript.CalcSignatureHash(u.script, hashType, msgTx.MsgTx, idx)
-	case ZecMsgTx:
+	case *ZecMsgTx:
 		if u.script == nil {
-			return calcSignatureHash(scriptPubKey, hashType, msgTx.MsgTx, idx, u.Amount())
+			return calcSignatureHash(scriptPubKey, hashType, msgTx, idx, u.Amount())
 		}
-		return calcSignatureHash(u.script, hashType, msgTx.MsgTx, idx, u.Amount())
+		return calcSignatureHash(u.script, hashType, msgTx, idx, u.Amount())
 	case BchMsgTx:
 		if u.script == nil {
 			return calcBip143SignatureHash(scriptPubKey, txscript.NewTxSigHashes(msgTx.MsgTx), hashType, msgTx.MsgTx, idx, u.Amount()), nil
@@ -302,210 +299,4 @@ func calcBip143SignatureHash(subScript []byte, sigHashes *txscript.TxSigHashes,
 type upgradeParam struct {
 	ActivationHeight uint32
 	BranchID         []byte
-}
-
-const (
-	sigHashMask                = 0x1f
-	blake2BSigHash             = "ZcashSigHash"
-	outputsHashPersonalization = "ZcashOutputsHash"
-
-	versionOverwinter        int32  = 3
-	versionOverwinterGroupID uint32 = 0x3C48270
-	versionSapling                  = 4
-	versionSaplingGroupID           = 0x892f2085
-)
-
-var upgradeParams = []upgradeParam{
-	{0, []byte{0x00, 0x00, 0x00, 0x00}},
-	{207500, []byte{0x19, 0x1B, 0xA8, 0x5B}},
-	{280000, []byte{0xBB, 0x09, 0xB8, 0x76}},
-	{584000, []byte{0x60, 0x0E, 0xB4, 0x2B}},
-}
-
-func calcSignatureHash(
-	subScript []byte,
-	hashType txscript.SigHashType,
-	tx *zecutil.MsgTx,
-	idx int,
-	amt Amount,
-) ([]byte, error) {
-	sigHashes, err := zecutil.NewTxSigHashes(tx)
-	if err != nil {
-		return nil, err
-	}
-
-	// As a sanity check, ensure the passed input index for the transaction
-	// is valid.
-	if idx > len(tx.TxIn)-1 {
-		return nil, fmt.Errorf("blake2bSignatureHash error: idx %d but %d txins", idx, len(tx.TxIn))
-	}
-
-	// We'll utilize this buffer throughout to incrementally calculate
-	// the signature hash for this transaction.
-	var sigHash bytes.Buffer
-
-	// << GetHeader
-	// First write out, then encode the transaction's nVersion number. Zcash current nVersion = 3
-	var bVersion [4]byte
-	binary.LittleEndian.PutUint32(bVersion[:], uint32(tx.Version)|(1<<31))
-	sigHash.Write(bVersion[:])
-
-	var versionGroupID = versionOverwinterGroupID
-	if tx.Version == versionSapling {
-		versionGroupID = versionSaplingGroupID
-	}
-
-	// << nVersionGroupId
-	// Version group ID
-	var nVersion [4]byte
-	binary.LittleEndian.PutUint32(nVersion[:], versionGroupID)
-	sigHash.Write(nVersion[:])
-
-	// Next write out the possibly pre-calculated hashes for the sequence
-	// numbers of all inputs, and the hashes of the previous outs for all
-	// outputs.
-	var zeroHash chainhash.Hash
-
-	// << hashPrevouts
-	// If anyone can pay isn't active, then we can use the cached
-	// hashPrevOuts, otherwise we just write zeroes for the prev outs.
-	if hashType&txscript.SigHashAnyOneCanPay == 0 {
-		sigHash.Write(sigHashes.HashPrevOuts[:])
-	} else {
-		sigHash.Write(zeroHash[:])
-	}
-
-	// << hashSequence
-	// If the sighash isn't anyone can pay, single, or none, the use the
-	// cached hash sequences, otherwise write all zeroes for the
-	// hashSequence.
-	if hashType&txscript.SigHashAnyOneCanPay == 0 &&
-		hashType&sigHashMask != txscript.SigHashSingle &&
-		hashType&sigHashMask != txscript.SigHashNone {
-		sigHash.Write(sigHashes.HashSequence[:])
-	} else {
-		sigHash.Write(zeroHash[:])
-	}
-
-	// << hashOutputs
-	// If the current signature mode isn't single, or none, then we can
-	// re-use the pre-generated hashoutputs sighash fragment. Otherwise,
-	// we'll serialize and add only the target output index to the signature
-	// pre-image.
-	if hashType&sigHashMask != txscript.SigHashSingle && hashType&sigHashMask != txscript.SigHashNone {
-		sigHash.Write(sigHashes.HashOutputs[:])
-	} else if hashType&sigHashMask == txscript.SigHashSingle && idx < len(tx.TxOut) {
-		var (
-			b bytes.Buffer
-			h chainhash.Hash
-		)
-		if err := wire.WriteTxOut(&b, 0, 0, tx.TxOut[idx]); err != nil {
-			return nil, err
-		}
-
-		var err error
-		if h, err = blake2bHash(b.Bytes(), []byte(outputsHashPersonalization)); err != nil {
-			return nil, err
-		}
-		sigHash.Write(h.CloneBytes())
-	} else {
-		sigHash.Write(zeroHash[:])
-	}
-
-	// << hashJoinSplits
-	sigHash.Write(zeroHash[:])
-
-	// << hashShieldedSpends
-	if tx.Version == versionSapling {
-		sigHash.Write(zeroHash[:])
-	}
-
-	// << hashShieldedOutputs
-	if tx.Version == versionSapling {
-		sigHash.Write(zeroHash[:])
-	}
-
-	// << nLockTime
-	var lockTime [4]byte
-	binary.LittleEndian.PutUint32(lockTime[:], tx.LockTime)
-	sigHash.Write(lockTime[:])
-
-	// << nExpiryHeight
-	var expiryTime [4]byte
-	binary.LittleEndian.PutUint32(expiryTime[:], tx.ExpiryHeight)
-	sigHash.Write(expiryTime[:])
-
-	// << valueBalance
-	if tx.Version == versionSapling {
-		var valueBalance [8]byte
-		binary.LittleEndian.PutUint64(valueBalance[:], 0)
-		sigHash.Write(valueBalance[:])
-	}
-
-	// << nHashType
-	var bHashType [4]byte
-	binary.LittleEndian.PutUint32(bHashType[:], uint32(hashType))
-	sigHash.Write(bHashType[:])
-
-	if idx != math.MaxUint32 {
-		// << prevout
-		// Next, write the outpoint being spent.
-		sigHash.Write(tx.TxIn[idx].PreviousOutPoint.Hash[:])
-		var bIndex [4]byte
-		binary.LittleEndian.PutUint32(bIndex[:], tx.TxIn[idx].PreviousOutPoint.Index)
-		sigHash.Write(bIndex[:])
-
-		// << scriptCode
-		// For p2wsh outputs, and future outputs, the script code is the
-		// original script, with all code separators removed, serialized
-		// with a var int length prefix.
-		// wire.WriteVarBytes(&sigHash, 0, subScript)
-		if err := wire.WriteVarBytes(&sigHash, 0, subScript); err != nil {
-			return nil, err
-		}
-
-		// << amount
-		// Next, add the input amount, and sequence number of the input being
-		// signed.
-		if err := binary.Write(&sigHash, binary.LittleEndian, amt); err != nil {
-			return nil, err
-		}
-
-		// << nSequence
-		var bSequence [4]byte
-		binary.LittleEndian.PutUint32(bSequence[:], tx.TxIn[idx].Sequence)
-		sigHash.Write(bSequence[:])
-	}
-
-	var h chainhash.Hash
-	if h, err = blake2bHash(sigHash.Bytes(), sigHashKey(tx.ExpiryHeight)); err != nil {
-		return nil, err
-	}
-
-	return h.CloneBytes(), nil
-}
-
-func blake2bHash(data, key []byte) (h chainhash.Hash, err error) {
-	bHash := blake2.New(&blake2.Config{
-		Size:     32,
-		Personal: key,
-	})
-
-	if _, err = bHash.Write(data); err != nil {
-		return h, err
-	}
-
-	err = (&h).SetBytes(bHash.Sum(nil))
-	return h, err
-}
-
-func sigHashKey(activationHeight uint32) []byte {
-	var i int
-	for i = len(upgradeParams) - 1; i >= 0; i-- {
-		if activationHeight >= upgradeParams[i].ActivationHeight {
-			break
-		}
-	}
-
-	return append([]byte(blake2BSigHash), upgradeParams[i].BranchID...)
 }

--- a/types/btctypes/zec.go
+++ b/types/btctypes/zec.go
@@ -1,0 +1,515 @@
+package btctypes
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/codahale/blake2"
+)
+
+const (
+	sigHashMask                 = 0x1f
+	blake2BSigHash              = "ZcashSigHash"
+	prevoutsHashPersonalization = "ZcashPrevoutHash"
+	sequenceHashPersonalization = "ZcashSequencHash"
+	outputsHashPersonalization  = "ZcashOutputsHash"
+
+	versionOverwinter        int32  = 3
+	versionOverwinterGroupID uint32 = 0x3C48270
+	versionSapling                  = 4
+	versionSaplingGroupID           = 0x892f2085
+)
+
+var upgradeParams = []upgradeParam{
+	{0, []byte{0x00, 0x00, 0x00, 0x00}},
+	{207500, []byte{0x19, 0x1B, 0xA8, 0x5B}},
+	{280000, []byte{0xBB, 0x09, 0xB8, 0x76}},
+	{584000, []byte{0x60, 0x0E, 0xB4, 0x2B}},
+}
+
+// ZecMsgTx zec fork
+type ZecMsgTx struct {
+	*wire.MsgTx
+	ExpiryHeight uint32
+}
+
+// witnessMarkerBytes are a pair of bytes specific to the witness encoding. If
+// this sequence is encoutered, then it indicates a transaction has iwtness
+// data. The first byte is an always 0x00 marker byte, which allows decoders to
+// distinguish a serialized transaction with witnesses from a regular (legacy)
+// one. The second byte is the Flag field, which at the moment is always 0x01,
+// but may be extended in the future to accommodate auxiliary non-committed
+// fields.
+var witnessMarkerBytes = []byte{0x00, 0x01}
+
+// TxHash generates the Hash for the transaction.
+func (msg *ZecMsgTx) TxHash() chainhash.Hash {
+	var buf bytes.Buffer
+	_ = msg.ZecEncode(&buf, 0, wire.BaseEncoding)
+	return chainhash.DoubleHashH(buf.Bytes())
+}
+
+// ZecEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+// See Serialize for encoding transactions to be stored to disk, such as in a
+// database, as opposed to encoding transactions for the wire.
+// msg.Version must be 3 or 4 and may or may not include the overwintered flag
+func (msg *ZecMsgTx) ZecEncode(w io.Writer, pver uint32, enc wire.MessageEncoding) error {
+	if err := binary.Write(w, binary.LittleEndian, uint32(msg.Version)|(1<<31)); err != nil {
+		return err
+	}
+
+	var versionGroupID = versionOverwinterGroupID
+	if msg.Version == versionSapling {
+		versionGroupID = versionSaplingGroupID
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, versionGroupID); err != nil {
+		return err
+	}
+
+	// If the encoding nVersion is set to WitnessEncoding, and the Flags
+	// field for the MsgTx aren't 0x00, then this indicates the transaction
+	// is to be encoded using the new witness inclusionary structure
+	// defined in BIP0144.
+	doWitness := enc == wire.WitnessEncoding && msg.HasWitness()
+	if doWitness {
+		// After the txn's Version field, we include two additional
+		// bytes specific to the witness encoding. The first byte is an
+		// always 0x00 marker byte, which allows decoders to
+		// distinguish a serialized transaction with witnesses from a
+		// regular (legacy) one. The second byte is the Flag field,
+		// which at the moment is always 0x01, but may be extended in
+		// the future to accommodate auxiliary non-committed fields.
+		if _, err := w.Write(witnessMarkerBytes); err != nil {
+			return err
+		}
+	}
+
+	count := uint64(len(msg.MsgTx.TxIn))
+	if err := writeVarInt(w, pver, count); err != nil {
+		return err
+	}
+
+	for _, ti := range msg.TxIn {
+		if err := writeTxIn(w, pver, msg.Version, ti); err != nil {
+			return err
+		}
+	}
+
+	count = uint64(len(msg.TxOut))
+	if err := writeVarInt(w, pver, count); err != nil {
+		return err
+	}
+
+	for _, to := range msg.TxOut {
+		if err := WriteTxOut(w, pver, msg.Version, to); err != nil {
+			return err
+		}
+	}
+
+	// If this transaction is a witness transaction, and the witness
+	// encoded is desired, then encode the witness for each of the inputs
+	// within the transaction.
+	if doWitness {
+		for _, ti := range msg.TxIn {
+			if err := writeTxWitness(w, pver, msg.Version, ti.Witness); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, msg.LockTime); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, msg.ExpiryHeight); err != nil {
+		return err
+	}
+
+	if msg.Version == versionSapling {
+		// valueBalance
+		if err := binary.Write(w, binary.LittleEndian, uint64(0)); err != nil {
+			return err
+		}
+
+		// nShieldedSpend
+		if err := writeVarInt(w, pver, 0); err != nil {
+			return err
+		}
+
+		// nShieldedOutput
+		if err := writeVarInt(w, pver, 0); err != nil {
+			return err
+		}
+	}
+
+	return writeVarInt(w, pver, 0)
+}
+
+// WriteTxOut encodes to into the bitcoin protocol encoding for a transaction
+// output (TxOut) to w.
+//
+// NOTE: This function is exported in order to allow txscript to compute the
+// new sighashes for witness transactions (BIP0143).
+func WriteTxOut(w io.Writer, pver uint32, version int32, to *wire.TxOut) error {
+	if err := binary.Write(w, binary.LittleEndian, uint64(to.Value)); err != nil {
+		return err
+	}
+	return writeVarBytes(w, pver, to.PkScript)
+}
+
+// writeTxIn encodes ti to the bitcoin protocol encoding for a transaction
+// input (TxIn) to w.
+func writeTxIn(w io.Writer, pver uint32, version int32, ti *wire.TxIn) error {
+	err := writeOutPoint(w, pver, version, &ti.PreviousOutPoint)
+	if err != nil {
+		return err
+	}
+
+	err = writeVarBytes(w, pver, ti.SignatureScript)
+	if err != nil {
+		return err
+	}
+
+	return binary.Write(w, binary.LittleEndian, ti.Sequence)
+}
+
+// writeOutPoint encodes op to the bitcoin protocol encoding for an OutPoint
+// to w.
+func writeOutPoint(w io.Writer, pver uint32, version int32, op *wire.OutPoint) error {
+	_, err := w.Write(op.Hash[:])
+	if err != nil {
+		return err
+	}
+	return binary.Write(w, binary.LittleEndian, op.Index)
+}
+
+// writeTxWitness encodes the bitcoin protocol encoding for a transaction
+// input's witness into to w.
+func writeTxWitness(w io.Writer, pver uint32, version int32, wit [][]byte) error {
+	err := writeVarInt(w, pver, uint64(len(wit)))
+	if err != nil {
+		return err
+	}
+	for _, item := range wit {
+		err = writeVarBytes(w, pver, item)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeVarInt serializes val to w using a variable number of bytes depending
+// on its value.
+func writeVarInt(w io.Writer, pver uint32, val uint64) error {
+	if val < 0xfd {
+		return binary.Write(w, binary.LittleEndian, uint8(val))
+	}
+
+	if val <= math.MaxUint16 {
+		err := binary.Write(w, binary.LittleEndian, 0xfd)
+		if err != nil {
+			return err
+		}
+		return binary.Write(w, binary.LittleEndian, uint16(val))
+	}
+
+	if val <= math.MaxUint32 {
+		err := binary.Write(w, binary.LittleEndian, 0xfe)
+		if err != nil {
+			return err
+		}
+		return binary.Write(w, binary.LittleEndian, uint32(val))
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, 0xff); err != nil {
+		return err
+	}
+	return binary.Write(w, binary.LittleEndian, val)
+}
+
+// writeVarBytes serializes a variable length byte array to w as a varInt
+// containing the number of bytes, followed by the bytes themselves.
+func writeVarBytes(w io.Writer, pver uint32, bytes []byte) error {
+	slen := uint64(len(bytes))
+	err := writeVarInt(w, pver, slen)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(bytes)
+	return err
+}
+
+// NewTxSigHashes computes, and returns the cached sighashes of the given
+// transaction.
+func NewTxSigHashes(tx *ZecMsgTx) (h *txscript.TxSigHashes, err error) {
+	h = &txscript.TxSigHashes{}
+
+	if h.HashPrevOuts, err = calcHashPrevOuts(tx); err != nil {
+		return
+	}
+
+	if h.HashSequence, err = calcHashSequence(tx); err != nil {
+		return
+	}
+
+	if h.HashOutputs, err = calcHashOutputs(tx); err != nil {
+		return
+	}
+
+	return
+}
+
+// calcHashPrevOuts calculates a single hash of all the previous outputs
+// (txid:index) referenced within the passed transaction. This calculated hash
+// can be re-used when validating all inputs spending segwit outputs, with a
+// signature hash type of SigHashAll. This allows validation to re-use previous
+// hashing computation, reducing the complexity of validating SigHashAll inputs
+// from  O(N^2) to O(N).
+func calcHashPrevOuts(tx *ZecMsgTx) (chainhash.Hash, error) {
+	var b bytes.Buffer
+	for _, in := range tx.TxIn {
+		// First write out the 32-byte transaction ID one of whose
+		// outputs are being referenced by this input.
+
+		b.Write(in.PreviousOutPoint.Hash[:])
+
+		// Next, we'll encode the index of the referenced output as a
+		// little endian integer.
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], in.PreviousOutPoint.Index)
+		b.Write(buf[:])
+	}
+
+	return blake2bHash(b.Bytes(), []byte(prevoutsHashPersonalization))
+}
+
+// calcHashSequence computes an aggregated hash of each of the sequence numbers
+// within the inputs of the passed transaction. This single hash can be re-used
+// when validating all inputs spending segwit outputs, which include signatures
+// using the SigHashAll sighash type. This allows validation to re-use previous
+// hashing computation, reducing the complexity of validating SigHashAll inputs
+// from O(N^2) to O(N).
+func calcHashSequence(tx *ZecMsgTx) (chainhash.Hash, error) {
+	var b bytes.Buffer
+	for _, in := range tx.TxIn {
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], in.Sequence)
+		b.Write(buf[:])
+	}
+
+	return blake2bHash(b.Bytes(), []byte(sequenceHashPersonalization))
+}
+
+// calcHashOutputs computes a hash digest of all outputs created by the
+// transaction encoded using the wire format. This single hash can be re-used
+// when validating all inputs spending witness programs, which include
+// signatures using the SigHashAll sighash type. This allows computation to be
+// cached, reducing the total hashing complexity from O(N^2) to O(N).
+func calcHashOutputs(tx *ZecMsgTx) (_ chainhash.Hash, err error) {
+	var b bytes.Buffer
+	for _, out := range tx.TxOut {
+		if err = wire.WriteTxOut(&b, 0, 0, out); err != nil {
+			return chainhash.Hash{}, err
+		}
+	}
+
+	return blake2bHash(b.Bytes(), []byte(outputsHashPersonalization))
+}
+
+func calcSignatureHash(
+	subScript []byte,
+	hashType txscript.SigHashType,
+	tx *ZecMsgTx,
+	idx int,
+	amt Amount,
+) ([]byte, error) {
+	sigHashes, err := NewTxSigHashes(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// As a sanity check, ensure the passed input index for the transaction
+	// is valid.
+	if idx > len(tx.TxIn)-1 {
+		return nil, fmt.Errorf("blake2bSignatureHash error: idx %d but %d txins", idx, len(tx.TxIn))
+	}
+
+	// We'll utilize this buffer throughout to incrementally calculate
+	// the signature hash for this transaction.
+	var sigHash bytes.Buffer
+
+	// << GetHeader
+	// First write out, then encode the transaction's nVersion number. Zcash current nVersion = 3
+	var bVersion [4]byte
+	binary.LittleEndian.PutUint32(bVersion[:], uint32(tx.Version)|(1<<31))
+	sigHash.Write(bVersion[:])
+
+	var versionGroupID = versionOverwinterGroupID
+	if tx.Version == versionSapling {
+		versionGroupID = versionSaplingGroupID
+	}
+
+	// << nVersionGroupId
+	// Version group ID
+	var nVersion [4]byte
+	binary.LittleEndian.PutUint32(nVersion[:], versionGroupID)
+	sigHash.Write(nVersion[:])
+
+	// Next write out the possibly pre-calculated hashes for the sequence
+	// numbers of all inputs, and the hashes of the previous outs for all
+	// outputs.
+	var zeroHash chainhash.Hash
+
+	// << hashPrevouts
+	// If anyone can pay isn't active, then we can use the cached
+	// hashPrevOuts, otherwise we just write zeroes for the prev outs.
+	if hashType&txscript.SigHashAnyOneCanPay == 0 {
+		sigHash.Write(sigHashes.HashPrevOuts[:])
+	} else {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << hashSequence
+	// If the sighash isn't anyone can pay, single, or none, the use the
+	// cached hash sequences, otherwise write all zeroes for the
+	// hashSequence.
+	if hashType&txscript.SigHashAnyOneCanPay == 0 &&
+		hashType&sigHashMask != txscript.SigHashSingle &&
+		hashType&sigHashMask != txscript.SigHashNone {
+		sigHash.Write(sigHashes.HashSequence[:])
+	} else {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << hashOutputs
+	// If the current signature mode isn't single, or none, then we can
+	// re-use the pre-generated hashoutputs sighash fragment. Otherwise,
+	// we'll serialize and add only the target output index to the signature
+	// pre-image.
+	if hashType&sigHashMask != txscript.SigHashSingle && hashType&sigHashMask != txscript.SigHashNone {
+		sigHash.Write(sigHashes.HashOutputs[:])
+	} else if hashType&sigHashMask == txscript.SigHashSingle && idx < len(tx.TxOut) {
+		var (
+			b bytes.Buffer
+			h chainhash.Hash
+		)
+		if err := wire.WriteTxOut(&b, 0, 0, tx.TxOut[idx]); err != nil {
+			return nil, err
+		}
+
+		var err error
+		if h, err = blake2bHash(b.Bytes(), []byte(outputsHashPersonalization)); err != nil {
+			return nil, err
+		}
+		sigHash.Write(h.CloneBytes())
+	} else {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << hashJoinSplits
+	sigHash.Write(zeroHash[:])
+
+	// << hashShieldedSpends
+	if tx.Version == versionSapling {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << hashShieldedOutputs
+	if tx.Version == versionSapling {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << nLockTime
+	var lockTime [4]byte
+	binary.LittleEndian.PutUint32(lockTime[:], tx.LockTime)
+	sigHash.Write(lockTime[:])
+
+	// << nExpiryHeight
+	var expiryTime [4]byte
+	binary.LittleEndian.PutUint32(expiryTime[:], tx.ExpiryHeight)
+	sigHash.Write(expiryTime[:])
+
+	// << valueBalance
+	if tx.Version == versionSapling {
+		var valueBalance [8]byte
+		binary.LittleEndian.PutUint64(valueBalance[:], 0)
+		sigHash.Write(valueBalance[:])
+	}
+
+	// << nHashType
+	var bHashType [4]byte
+	binary.LittleEndian.PutUint32(bHashType[:], uint32(hashType))
+	sigHash.Write(bHashType[:])
+
+	if idx != math.MaxUint32 {
+		// << prevout
+		// Next, write the outpoint being spent.
+		sigHash.Write(tx.TxIn[idx].PreviousOutPoint.Hash[:])
+		var bIndex [4]byte
+		binary.LittleEndian.PutUint32(bIndex[:], tx.TxIn[idx].PreviousOutPoint.Index)
+		sigHash.Write(bIndex[:])
+
+		// << scriptCode
+		// For p2wsh outputs, and future outputs, the script code is the
+		// original script, with all code separators removed, serialized
+		// with a var int length prefix.
+		// wire.WriteVarBytes(&sigHash, 0, subScript)
+		if err := wire.WriteVarBytes(&sigHash, 0, subScript); err != nil {
+			return nil, err
+		}
+
+		// << amount
+		// Next, add the input amount, and sequence number of the input being
+		// signed.
+		if err := binary.Write(&sigHash, binary.LittleEndian, amt); err != nil {
+			return nil, err
+		}
+
+		// << nSequence
+		var bSequence [4]byte
+		binary.LittleEndian.PutUint32(bSequence[:], tx.TxIn[idx].Sequence)
+		sigHash.Write(bSequence[:])
+	}
+
+	var h chainhash.Hash
+	if h, err = blake2bHash(sigHash.Bytes(), sigHashKey(tx.ExpiryHeight)); err != nil {
+		return nil, err
+	}
+
+	return h.CloneBytes(), nil
+}
+
+func blake2bHash(data, key []byte) (h chainhash.Hash, err error) {
+	bHash := blake2.New(&blake2.Config{
+		Size:     32,
+		Personal: key,
+	})
+
+	if _, err = bHash.Write(data); err != nil {
+		return h, err
+	}
+
+	err = (&h).SetBytes(bHash.Sum(nil))
+	return h, err
+}
+
+func sigHashKey(activationHeight uint32) []byte {
+	var i int
+	for i = len(upgradeParams) - 1; i >= 0; i-- {
+		if activationHeight >= upgradeParams[i].ActivationHeight {
+			break
+		}
+	}
+
+	return append([]byte(blake2BSigHash), upgradeParams[i].BranchID...)
+}


### PR DESCRIPTION
* Removed dependency on zecutil, as it hasn't been updated to work with the ZCash blossom upgrade.
* Add BtcCompat P2SH and P2PKH addresses, for supporting other bitcoin variants. 