### PR TITLE
Fixed BitcoinCash address decoder

### DIFF
--- a/types/btctypes/address_test.go
+++ b/types/btctypes/address_test.go
@@ -1,0 +1,15 @@
+package btctypes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	_ "github.com/renproject/mercury/types/btctypes"
+)
+
+var _ = Describe("btctypes", func() {
+	Context("when decoding testnet bitcoin cash addresses", func() {
+		It("should decode a valid bitcoin cash address", func() {
+			Expect(true).To(BeTrue())
+		})
+	})
+})

--- a/types/btctypes/bch/bch.go
+++ b/types/btctypes/bch/bch.go
@@ -168,16 +168,17 @@ func AppendChecksum(prefix string, payload []byte) []byte {
 
 func DecodeAddress(addr string, params *chaincfg.Params) (btcutil.Address, error) {
 	if addrParts := strings.Split(addr, ":"); len(addrParts) != 1 {
-		addr = addrParts[0]
+		addr = addrParts[1]
 	}
 
-	addrBytes, err := bech32.ConvertBits(BCashCodec.DecodeString(addr), 5, 8, false)
+	decoded := BCashCodec.DecodeString(addr)
+	if !VerifyChecksum(prefix(params), decoded) {
+		return nil, btcutil.ErrChecksumMismatch
+	}
+
+	addrBytes, err := bech32.ConvertBits(decoded[:len(decoded)-8], 5, 8, false)
 	if err != nil {
 		return nil, err
-	}
-
-	if !VerifyChecksum(prefix(params), addrBytes) {
-		return nil, btcutil.ErrChecksumMismatch
 	}
 
 	switch len(addrBytes) - 1 {

--- a/types/btctypes/bch/bch_suite_test.go
+++ b/types/btctypes/bch/bch_suite_test.go
@@ -1,0 +1,13 @@
+package bch_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bch Suite")
+}

--- a/types/btctypes/bch/bch_test.go
+++ b/types/btctypes/bch/bch_test.go
@@ -1,0 +1,23 @@
+package bch_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/mercury/types/btctypes/bch"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+var _ = Describe("bch", func() {
+	Context("when decoding testnet bitcoin cash addresses", func() {
+		It("should decode a valid bitcoin cash address", func() {
+			_, err := DecodeAddress("qrch9dvf9rc45p728n7d8p4r7n067jrdxgjyklgcg6", &chaincfg.TestNet3Params)
+			Expect(err).Should(BeNil())
+		})
+
+		It("should decode a valid bitcoin cash address with a prefix", func() {
+			_, err := DecodeAddress("bchtest:qrch9dvf9rc45p728n7d8p4r7n067jrdxgjyklgcg6", &chaincfg.TestNet3Params)
+			Expect(err).Should(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
* Fixed BitcoinCash address decoder. 
* Add tests to check BitcoinCash address decoding.